### PR TITLE
Fix for plugin initialization. BCAPP-3181

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -50,6 +50,7 @@ export const PlayerEvents = Object.freeze({
   ERROR: 'error',
   PAUSE: 'pause',
   PLAY: 'play',
+  PLAYING: 'playing',
   TIME_UPDATE: 'timeupdate'
 });
 

--- a/src/embed.js
+++ b/src/embed.js
@@ -274,8 +274,10 @@ class PtvEmbed {
       const payload = parseMessageData(data);
 
       // If we receive any kind of message then we know the SDK has loaded.
-      this.isSdkLoaded_ = true;
-      this.applyPreloadState_();
+      if(!this.isSdkLoaded_) {
+        this.isSdkLoaded_ = true;
+        this.applyPreloadState_();
+      }
 
       switch (payload.type) {
       case SdkEvents.CONFIG_FAILURE:

--- a/src/embed.js
+++ b/src/embed.js
@@ -274,7 +274,7 @@ class PtvEmbed {
       const payload = parseMessageData(data);
 
       // If we receive any kind of message then we know the SDK has loaded.
-      if(!this.isSdkLoaded_) {
+      if (!this.isSdkLoaded_) {
         this.isSdkLoaded_ = true;
         this.applyPreloadState_();
       }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -155,7 +155,7 @@ class Ptv extends Plugin {
    * Add videojs player listeners.
    */
   addPlayerListeners_() {
-    if (!this.options.autoWireEvents) return;
+    if (!this.options.autoWireEvents) { return };
     this.player.one(PlayerEvents.PLAYING, () => {
       this.start();
     });
@@ -171,7 +171,7 @@ class Ptv extends Plugin {
    * Remove videojs player listeners.
    */
   removePlayerListeners_() {
-    if (!this.options.autoWireEvents) return;
+    if (!this.options.autoWireEvents) { return };
     this.player.off([
       PlayerEvents.ENDED,
       PlayerEvents.ERROR,

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -155,7 +155,9 @@ class Ptv extends Plugin {
    * Add videojs player listeners.
    */
   addPlayerListeners_() {
-    if (!this.options.autoWireEvents) { return };
+    if (!this.options.autoWireEvents) {
+      return;
+    }
     this.player.one(PlayerEvents.PLAYING, () => this.start());
     this.player.on(PlayerEvents.ENDED, () => this.stop());
     this.player.on(PlayerEvents.ERROR, () => this.stop());
@@ -169,7 +171,9 @@ class Ptv extends Plugin {
    * Remove videojs player listeners.
    */
   removePlayerListeners_() {
-    if (!this.options.autoWireEvents) { return };
+    if (!this.options.autoWireEvents) {
+      return;
+    }
     this.player.off([
       PlayerEvents.ENDED,
       PlayerEvents.ERROR,

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -16,6 +16,7 @@ const Plugin = videojs.getPlugin('plugin');
 // Default options for the plugin.
 const defaults = {
   apiHost: ApiHosts.PRODUCTION,
+  autoWireEvents: true,
   channelId: null,
   debug: false,
   enableGeoBlock: false,
@@ -154,6 +155,7 @@ class Ptv extends Plugin {
    * Add videojs player listeners.
    */
   addPlayerListeners_() {
+    if (!this.options.autoWireEvents) return;
     this.player.one(PlayerEvents.PLAYING, () => {
       this.start();
     });
@@ -169,6 +171,7 @@ class Ptv extends Plugin {
    * Remove videojs player listeners.
    */
   removePlayerListeners_() {
+    if (!this.options.autoWireEvents) return;
     this.player.off([
       PlayerEvents.ENDED,
       PlayerEvents.ERROR,

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -64,9 +64,6 @@ class Ptv extends Plugin {
 
     this.options = videojs.mergeOptions(defaults, options);
 
-    // Setup other player events
-    this.addPlayerListeners_();
-
     // Handle player events.
     this.player.ready(this.handlePlayerReady_.bind(this));
   }
@@ -85,6 +82,9 @@ class Ptv extends Plugin {
 
     // Create iframe instance.
     this.embed = new PtvEmbed(this.options, callbacks);
+
+    // Setup other player events
+    this.addPlayerListeners_();
 
     // Place iFrame after video element and before the poster image element.
     this.player.posterImage.el().before(this.embed.el);
@@ -154,7 +154,10 @@ class Ptv extends Plugin {
    * Add videojs player listeners.
    */
   addPlayerListeners_() {
-    this.player.one(PlayerEvents.PLAY, () => this.start());
+    this.player.one(PlayerEvents.PLAYING, () => {
+      console.log('playing from videojs')
+      this.start()
+    });
     this.player.on(PlayerEvents.ENDED, () => this.stop());
     this.player.on(PlayerEvents.ERROR, () => this.stop());
     this.player.on(PlayerEvents.PAUSE, () => this.hide());
@@ -172,6 +175,7 @@ class Ptv extends Plugin {
       PlayerEvents.ERROR,
       PlayerEvents.PAUSE,
       PlayerEvents.PLAY,
+      PlayerEvents.PLAYING,
       PlayerEvents.TIME_UPDATE
     ]);
   }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -155,8 +155,7 @@ class Ptv extends Plugin {
    */
   addPlayerListeners_() {
     this.player.one(PlayerEvents.PLAYING, () => {
-      console.log('playing from videojs')
-      this.start()
+      this.start();
     });
     this.player.on(PlayerEvents.ENDED, () => this.stop());
     this.player.on(PlayerEvents.ERROR, () => this.stop());

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -179,9 +179,9 @@ QUnit.module('player events', function(hooks) {
   QUnit.test('play starts plugin only once', function(assert) {
     const spy = sinon.spy(this.ptv, 'start');
 
-    this.player.trigger(PlayerEvents.PLAY);
+    this.player.trigger(PlayerEvents.PLAYING);
     assert.ok(spy.calledOnce, 'api called');
-    this.player.trigger(PlayerEvents.PLAY);
+    this.player.trigger(PlayerEvents.PLAYING);
     assert.ok(spy.calledOnce, 'api called only once');
   });
 


### PR DESCRIPTION
Solves the issue of receiving `play` before `ready` from `videojs` by ensuring we don't setup media event listeners until after the plugin `ready` event is received from `videojs`! 
Seems a bit crazy but `play` has another chance to be triggered when the SDK config load handler is triggered or when the next `play` event is received (in case the player was paused on config load) after user interaction.

Another important change here is to use `playing` event instead of `play` to trigger our own SDK `APP_START` message. That change is based on this info here 
http://videojs.github.io/videojs-contrib-ads/integrator/redispatch.html
(NOTE: `videojs-ima` is present on the True page, which uses `videojs-contrib-ads`) 


https://prometheantv.atlassian.net/browse/BCAPP-3181